### PR TITLE
Refactor GitHub Actions to use npm for builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy React App to Hostinger
 on:
   push:
     branches:
-      - master
+      - master  # or main, depending on your repo
 
 jobs:
   build-deploy:
@@ -18,22 +18,17 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-
       - name: Install dependencies
-        run: pnpm install
+        run: npm ci
 
       - name: Build project
-        run: pnpm run build
+        run: npm run build
 
-      - name: Deploy build folder via FTP
+      - name: Deploy via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: dist/
-          server-dir: public_html/
+          local-dir: build
+          server-dir: public_html


### PR DESCRIPTION
Switch the GitHub Actions workflow from pnpm to npm for dependency installation and the build process, ensuring compatibility and simplifying the setup.